### PR TITLE
fix up runtime crash under RHEL-8.0

### DIFF
--- a/cbio.c
+++ b/cbio.c
@@ -88,6 +88,19 @@ int BIO_s_custom_gets(BIO *b, char *data, int size);
 
 int BIO_s_custom_puts(BIO *b, const char *data);
 
+#if defined(OPENSSL_NO_SCTP)
+/* I would like the following definitions to be available even when SCTP feature was disabled in OpenSSL */
+#define BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY 51
+#define BIO_CTRL_DGRAM_SCTP_NEXT_AUTH_KEY 52
+#define BIO_CTRL_DGRAM_SCTP_AUTH_CCS_RCVD 53
+#define BIO_CTRL_DGRAM_SCTP_GET_SNDINFO 60
+#define BIO_CTRL_DGRAM_SCTP_SET_SNDINFO 61
+#define BIO_CTRL_DGRAM_SCTP_GET_RCVINFO 62
+#define BIO_CTRL_DGRAM_SCTP_SET_RCVINFO 63
+#define BIO_CTRL_DGRAM_SCTP_GET_PRINFO 64
+#define BIO_CTRL_DGRAM_SCTP_SET_PRINFO 65
+#define BIO_CTRL_DGRAM_SCTP_SAVE_SHUTDOWN 70
+#endif /* end SCTP stuff */
 
 long BIO_s_custom_ctrl(BIO *b, int cmd, long larg, void *pargs)
 {
@@ -122,6 +135,22 @@ long BIO_s_custom_ctrl(BIO *b, int cmd, long larg, void *pargs)
         case BIO_CTRL_PUSH: // 6
         case BIO_CTRL_POP: // 7
         case BIO_CTRL_DGRAM_SET_NEXT_TIMEOUT: // 45
+            ret = 0;
+            break;
+        /* We need to handle/ignore the following SCTP control commands: */
+        case BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY:
+        case BIO_CTRL_DGRAM_SCTP_NEXT_AUTH_KEY:
+        case BIO_CTRL_DGRAM_SCTP_AUTH_CCS_RCVD:
+        case BIO_CTRL_DGRAM_SCTP_GET_SNDINFO:
+        case BIO_CTRL_DGRAM_SCTP_SET_SNDINFO:
+        case BIO_CTRL_DGRAM_SCTP_GET_RCVINFO:
+        case BIO_CTRL_DGRAM_SCTP_SET_RCVINFO:
+        case BIO_CTRL_DGRAM_SCTP_GET_PRINFO:
+        case BIO_CTRL_DGRAM_SCTP_SET_PRINFO:
+        case BIO_CTRL_DGRAM_SCTP_SAVE_SHUTDOWN:
+            /* Tested against OpenSSL 1.1.1 shipped by RedHat RHEL-8.0.
+             * See bug report: https://github.com/stepheny/openssl-dtls-custom-bio/issues/3
+             */
             ret = 0;
             break;
         default:


### PR DESCRIPTION
RedHat's RHEL-8.0 has enabled the SCTP feature of OpenSSL 1.1.1 by default.

The BIO_s_custom_ctrl() method has a bug that it would crash on cmd 51  BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY:

```
[liuqun@RHEL8]$ ./client 127.0.0.1:4433
SSL_CTX_load_verify_locations -> 1
SSL_CTX_set_default_verify_file -> 1
BIO_s_custom_create(BIO[0x0000000001DE1370])
BIO_s_custom_write(BIO[0x0000000001DE1370], buf[0x0000000001DFB6E0], dlen[219])
>> INET: 127.0.0.1:4433
  219 bytes sent
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 0
<< 36 bytes
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 1
  buf[0x0000000001DEC760]
BIO_s_custom_write(BIO[0x0000000001DE1370], buf[0x0000000001DFB6E0], dlen[227])
>> INET: 127.0.0.1:4433
  227 bytes sent
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 0
<< 1500 bytes
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 1
  buf[0x0000000001E1D5F0]
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 0
<< 531 bytes
BIO_s_custom_read(BIO[0x0000000001DE1370], data[0x0000000001DF24A3], dlen[16717])
  probe peekmode 0
  data[0x00007FFEB7605248] queue: 1
  buf[0x0000000001E1DDD0]
BIO_s_custom_write(BIO[0x0000000001DE1370], buf[0x0000000001DFB6E0], dlen[1495])
>> INET: 127.0.0.1:4433
  1495 bytes sent
BIO_s_custom_ctrl(BIO[0x0000000001DE1370], cmd[51], larg[64], pargs[0x00007FFEB7605010])
  unknown cmd: 51
Trace/breakpoint trap (core dumped)
```

cmd 51 is `BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY`:

See /usr/include/openssl/bio.h
```
# ifndef OPENSSL_NO_SCTP
/* SCTP stuff */
#  define BIO_CTRL_DGRAM_SCTP_ADD_AUTH_KEY                51
#  define BIO_CTRL_DGRAM_SCTP_NEXT_AUTH_KEY               52
#  define BIO_CTRL_DGRAM_SCTP_AUTH_CCS_RCVD               53
#  define BIO_CTRL_DGRAM_SCTP_GET_SNDINFO         60
#  define BIO_CTRL_DGRAM_SCTP_SET_SNDINFO         61
#  define BIO_CTRL_DGRAM_SCTP_GET_RCVINFO         62
#  define BIO_CTRL_DGRAM_SCTP_SET_RCVINFO         63
#  define BIO_CTRL_DGRAM_SCTP_GET_PRINFO                  64
#  define BIO_CTRL_DGRAM_SCTP_SET_PRINFO                  65
#  define BIO_CTRL_DGRAM_SCTP_SAVE_SHUTDOWN               70
# endif
```

Fixes #3 